### PR TITLE
Add a container creation job

### DIFF
--- a/.github/workflows/create_containers.yml
+++ b/.github/workflows/create_containers.yml
@@ -1,0 +1,37 @@
+name: Create containers
+on:
+  workflow_dispatch:
+  schedule:
+    - cron:  '0 0 * * *'
+
+permissions:
+  contents: read
+
+jobs:
+  push_to_registry:
+    permissions:
+      packages: write # for docker/build-push-action
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [arch]
+
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Push to GitHub Packages
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        with:
+          context: .
+          file: Dockerfile.${{matrix.os}}
+          push: true
+          tags: ghcr.io/opengamingcollective/kernel-packages/linux-${{matrix.os}}:latest

--- a/Dockerfile.arch
+++ b/Dockerfile.arch
@@ -1,0 +1,106 @@
+FROM archlinux:latest
+ENV LANG=en_US.UTF-8
+ENV LC_ALL=en_US.UTF-8
+ENV CI_NETWORK=true
+RUN echo fubar > /etc/machine-id
+RUN sed "s,#en_US.UTF-8,en_US.UTF-8," /etc/locale.gen -i
+RUN echo "LANG=en_US.UTF-8" > /etc/locale.conf
+RUN locale-gen
+RUN pacman -Sy --noconfirm archlinux-keyring
+RUN pacman -Syu --noconfirm \
+        audit                   \
+        bash                    \
+        base-devel              \
+        ca-certificates-mozilla \
+        coreutils               \
+        cryptsetup              \
+        clang			\
+        cpio			\
+        curl                    \
+        dbus-broker             \
+        dbus-broker-units       \
+        dbus-units              \
+        device-mapper           \
+        e2fsprogs               \
+        expat                   \
+        filesystem              \
+        gcc-libs                \
+        gc			\
+        gdbm                    \
+        gettext                 \
+        glib2                   \
+        glibc                   \
+        gnupg                   \
+        gnutls                  \
+        gpgme                   \
+        graphviz		\
+        guile			\
+        hwdata                  \
+        iana-etc                \
+        icu                     \
+        imagemagick		\
+        iproute2                \
+        iptables                \
+        iputils                 \
+        jansson                 \
+        json-c                  \
+        kbd                     \
+        kmod                    \
+        krb5                    \
+        leancrypto              \
+        libarchive              \
+        libbpf                  \
+        libcap                  \
+        libelf                  \
+        libffi                  \
+        libgcrypt               \
+        libgpg-error            \
+        libidn2                 \
+        libksba                 \
+        libldap                 \
+        libmakepkg-dropins      \
+        libnftnl                \
+        libnghttp2              \
+        libnghttp3              \
+        libnl                   \
+        libp11-kit              \
+        libpcap                 \
+        extra/libsysprof-capture     \
+        libtirpc                \
+        libusb                  \
+        libxcrypt               \
+        libxml2                 \
+        linux-api-headers       \
+        lld			\
+        llvm			\
+        ncurses                 \
+        nettle                  \
+        openssl                 \
+        p11-kit                 \
+        pacman                  \
+        pacman-mirrorlist       \
+        pahole			\
+        pam                     \
+        pambase                 \
+        pciutils                \
+        pcre2                   \
+        pinentry                \
+        python			\
+        python-sphinx		\
+        rust			\
+        rust-bindgen		\
+        rust-src		\
+        readline                \
+	sbsigntools		\
+        shadow                  \
+        sqlite                  \
+        systemd                 \
+        systemd-libs            \
+        systemd-sysvcompat      \
+        texlive-latexextra      \
+        tzdata                  \
+        util-linux              \
+        util-linux-libs         \
+        xz
+WORKDIR /github/workspace
+CMD ["/bin/bash"]


### PR DESCRIPTION
The basic design is that it's a matrix for all supported base OSes. Launching the container will execute a build script.

Initially only arch is setup.