### PR TITLE
feat: Add ccache to kernel build workflows

### DIFF
--- a/.github/workflows/arch.yaml
+++ b/.github/workflows/arch.yaml
@@ -65,6 +65,13 @@ jobs:
                   cp -vR * /home/build/linux
                   chown -vR build /home/build/linux
 
+            - name: Restore ccache
+              uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+              with:
+                  path: .ccache
+                  key: ccache-arch-${{ hashFiles('config') }}
+                  restore-keys: ccache-arch-
+
             - name: Set up pacman keyring
               run: |
                   pacman-key --init
@@ -73,13 +80,21 @@ jobs:
 
             - name: Install dependencies
               run: |
-                  pacman -Syu --noconfirm bc cpio gettext jq libelf pahole perl python rust rust-bindgen rust-src tar xz graphviz imagemagick python-sphinx python-yaml texlive-latexextra
+                  pacman -Syu --noconfirm bc ccache cpio gettext libelf pahole perl python rust rust-bindgen rust-src tar xz graphviz imagemagick python-sphinx python-yaml texlive-latexextra
+
+            - name: Configure ccache
+              run: |
+                  mkdir -p $GITHUB_WORKSPACE/.ccache
+                  chown -R build $GITHUB_WORKSPACE/.ccache
+                  export CCACHE_DIR=$GITHUB_WORKSPACE/.ccache
+                  ccache -M 3G
+                  ccache -z
 
             - name: Build linux package
               id: build-kernel-package
               shell: bash
               run: |
-                  su build bash -c "cd /home/build/linux/arch && MAKEFLAGS=-j$(nproc) makepkg --skippgpcheck"
+                  su build bash -c "export CC='ccache gcc' CCACHE_DIR=$GITHUB_WORKSPACE/.ccache CCACHE_BASEDIR=/home/build/linux/arch/src/linux-6.19.6 && cd /home/build/linux/arch && MAKEFLAGS=-j$(nproc) makepkg --skippgpcheck"
                   . /home/build/linux/arch/PKGBUILD
                   full_version=${pkgver}-${pkgrel}
                   echo "full_version=$full_version" >> "$GITHUB_OUTPUT"
@@ -144,3 +159,15 @@ jobs:
                     --certificate-identity-regexp=".*" \
                     --certificate-oidc-issuer="https://token.actions.githubusercontent.com" \
                     "${REPO}:${VERSION}"
+
+            - name: ccache statistics
+              if: success() || failure()
+              run: |
+                  CCACHE_DIR=$GITHUB_WORKSPACE/.ccache ccache -s
+
+            - name: Save ccache
+              if: startsWith(github.ref, 'refs/tags/')
+              uses: actions/cache/save@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+              with:
+                  path: .ccache
+                  key: ccache-arch-${{ hashFiles('config') }}

--- a/.github/workflows/nobara.yaml
+++ b/.github/workflows/nobara.yaml
@@ -58,13 +58,24 @@ jobs:
               with:
                   persist-credentials: false
 
+            - name: Restore ccache
+              uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+              with:
+                  path: .ccache
+                  key: ccache-nobara-${{ hashFiles('config') }}
+                  restore-keys: ccache-nobara-
+
             - name: Dependencies
               run: |
+                  dnf -y install ccache jq
                   dnf -y builddep nobara/kernel.spec
-                  dnf -y install jq
 
             - name: build
               run: |
+                  export CC="ccache gcc"
+                  export CCACHE_DIR=$GITHUB_WORKSPACE/.ccache
+                  export CCACHE_BASEDIR=$GITHUB_WORKSPACE/rpmbuild/BUILD
+
                   TOPDIR="$(pwd)/rpmbuild"
 
                   mkdir -p "$TOPDIR"/{BUILD,BUILDROOT,RPMS,SOURCES,SPECS,SRPMS}
@@ -136,3 +147,15 @@ jobs:
                     --certificate-identity-regexp=".*" \
                     --certificate-oidc-issuer="https://token.actions.githubusercontent.com" \
                     "${REPO}:${VERSION}"
+
+            - name: ccache statistics
+              if: success() || failure()
+              run: |
+                  CCACHE_DIR=$GITHUB_WORKSPACE/.ccache ccache -s
+
+            - name: Save ccache
+              if: startsWith(github.ref, 'refs/tags/')
+              uses: actions/cache/save@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+              with:
+                  path: .ccache
+                  key: ccache-nobara-${{ hashFiles('config') }}

--- a/.github/workflows/ubuntu.yaml
+++ b/.github/workflows/ubuntu.yaml
@@ -58,6 +58,13 @@ jobs:
               with:
                   persist-credentials: false
 
+            - name: Restore ccache
+              uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+              with:
+                  path: .ccache
+                  key: ccache-ubuntu-${{ hashFiles('config') }}
+                  restore-keys: ccache-ubuntu-
+
             - name: Dependencies
               run: |
                   export DEBIAN_FRONTEND=noninteractive
@@ -76,6 +83,9 @@ jobs:
 
             - name: Build
               run: |
+                  export CC="ccache gcc"
+                  export CCACHE_DIR=$GITHUB_WORKSPACE/.ccache
+                  export CCACHE_BASEDIR=$GITHUB_WORKSPACE/linux-6.19.6
                   cd linux-6.19.6
                   make olddefconfig
                   fakeroot make -j$(nproc) bindeb-pkg
@@ -140,3 +150,15 @@ jobs:
                     --certificate-identity-regexp=".*" \
                     --certificate-oidc-issuer="https://token.actions.githubusercontent.com" \
                     "${REPO}:${VERSION}"
+
+            - name: ccache statistics
+              if: success() || failure()
+              run: |
+                  CCACHE_DIR=$GITHUB_WORKSPACE/.ccache ccache -s
+
+            - name: Save ccache
+              if: startsWith(github.ref, 'refs/tags/')
+              uses: actions/cache/save@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+              with:
+                  path: .ccache
+                  key: ccache-ubuntu-${{ hashFiles('config') }}


### PR DESCRIPTION
Saving of the cache is intentionally skipped for anything but tagged releases. All others will get a copy of the last tagged release's cache to accelerate things.