### PR TITLE
chore: Bump GitHub actions

### DIFF
--- a/.github/workflows/arch.yaml
+++ b/.github/workflows/arch.yaml
@@ -194,7 +194,7 @@ jobs:
 
             - name: Setup Cosign
               if: startsWith(github.ref, 'refs/tags/')
-              uses: sigstore/cosign-installer@ba7bc0a3fef59531c69a25acd34668d6d3fe6f22 # v4.1.0
+              uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
 
             - name: Login to ghcr.io
               if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/fedora.yaml
+++ b/.github/workflows/fedora.yaml
@@ -181,7 +181,7 @@ jobs:
 
             - name: Setup Cosign
               if: startsWith(github.ref, 'refs/tags/')
-              uses: sigstore/cosign-installer@ba7bc0a3fef59531c69a25acd34668d6d3fe6f22 # v4.1.0
+              uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
 
             - name: Login to ghcr.io
               if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -73,6 +73,6 @@ jobs:
       # Upload the results to GitHub's code scanning dashboard (optional).
       # Commenting out will disable upload of results to your repo's Code Scanning dashboard
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@0d579ffd059c29b07949a3cce3983f0780820c98 # v4
+        uses: github/codeql-action/upload-sarif@c10b8064de6f491fea524254123dbe5e09572f13 # v4.35.1
         with:
           sarif_file: results.sarif

--- a/.github/workflows/ubuntu.yaml
+++ b/.github/workflows/ubuntu.yaml
@@ -166,7 +166,7 @@ jobs:
 
             - name: Setup Cosign
               if: startsWith(github.ref, 'refs/tags/')
-              uses: sigstore/cosign-installer@ba7bc0a3fef59531c69a25acd34668d6d3fe6f22 # v4.1.0
+              uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
 
             - name: Login to ghcr.io
               if: startsWith(github.ref, 'refs/tags/')


### PR DESCRIPTION
Bump cosign-installer to v4.1.1 and codeql-action to v4.35.1. The Node.js 20 deprecation warning comes from oras-project/setup-oras, which is still on node20. There's an open PR to fix it: https://github.com/oras-project/setup-oras/pull/146. Once that merges and a new release is cut, we can bump the setup-oras pin and the warning goes away.