### PR TITLE
feat: add NixOS kernel packaging

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1777954456,
+        "narHash": "sha256-hGdgeU2Nk87RAuZyYjyDjFL6LK7dAZN5RE9+hrDTkDU=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "549bd84d6279f9852cae6225e372cc67fb91a4c1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,21 @@
+{
+  description = "OpenGamingCollective Kernel Packages";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
+  };
+
+  outputs =
+    { self, nixpkgs }:
+    {
+      packages.x86_64-linux =
+        let
+          pkgs = nixpkgs.legacyPackages.x86_64-linux;
+          lib = pkgs.lib;
+        in
+        {
+          default = lib.recurseIntoAttrs (pkgs.linuxPackagesFor self.packages."x86_64-linux".linux-ogc);
+          linux-ogc = pkgs.callPackage ./nix/package.nix { };
+        };
+    };
+}

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,0 +1,90 @@
+{
+  lib,
+  fetchurl,
+  buildLinux,
+  ...
+}:
+let
+  kernel-version = "6.19.14";
+  ogc-revision = "ogc2";
+  version = "${kernel-version}-${ogc-revision}";
+  kernelSrc = fetchurl {
+    url = "https://github.com/OpenGamingCollective/linux/archive/refs/tags/v${version}.tar.gz";
+    hash = "sha256-LfrHohmdIW/YCU4LYrWYLcqItTSSHUQ9iLnfnR0o9Gc=";
+  };
+  configs = [
+    ../config/ogc.config.set
+    ../config/ogc.config.unset
+  ];
+
+  # Build the structured kernel config from one or more configs from the `configs` array
+  kernelConfig = lib.pipe configs [
+    # Read each config file into a string
+    (configs: map (config: builtins.readFile config) configs)
+    # Join all configs into a single string
+    (configs: lib.strings.join "\n" configs)
+    # Split the single config into lines
+    (config: lib.strings.splitString "\n" config)
+    # Find all lines that start with "CONFIG_"
+    (lines: lib.strings.filter (line: (builtins.match "^CONFIG_.*" line) != null) lines)
+    # Strip the "CONFIG_" prefix of each kernel option so it can be in `structuredExtraConfig` format
+    # E.g. "CONFIG_NTSYNC=m" -> "NTSYNC=m"
+    (lines: map (line: lib.strings.removePrefix "CONFIG_" line) lines)
+    # Convert each stripped line into key/value pairs
+    # E.g. "NTSYNC=m" -> ["NTSYNC" "m"]
+    (lines_stripped: map (line: builtins.split "=" line) lines_stripped)
+    # Convert each key/value pair into an attribute set in the form of: {"name" = key; "value" = value;}
+    # E.g. ["NTSYNC" "m"] -> {"name" = "NTSYNC"; "value" = lib.kernel.module;}
+    (kvPairs: map kvpairToOption kvPairs)
+    # Convert the list of attribute sets into a single combined attribute set that will
+    # be used as the `structuredExtraConfig`.
+    # E.g.
+    # {
+    #   NTSYNC = lib.kernel.module;
+    #   HID_ASUS = lib.kernel.module;
+    #   ...
+    # }
+    (attrSets: builtins.listToAttrs attrSets)
+  ];
+
+  # Function for converting a key/value pair into a kernel option attribute set
+  # E.g. "NTSYNC=m" -> {"name": "NTSYNC", "value": lib.kernel.module}
+  kvpairToOption =
+    kv_pair:
+    if (builtins.length kv_pair) == 1 then
+      let
+        key = builtins.elemAt kv_pair 0;
+      in
+      {
+        "name" = key;
+        "value" = lib.mkDefault lib.kernel.unset;
+      }
+    else
+      let
+        key = builtins.elemAt kv_pair 0;
+        value = builtins.elemAt kv_pair 1;
+      in
+      {
+        "name" = key;
+        "value" =
+          if value == "y" then
+            lib.mkDefault lib.kernel.yes
+          else if value == "m" then
+            lib.mkDefault lib.kernel.module
+          else if value == "n" then
+            lib.mkDefault lib.kernel.no
+          else
+            lib.mkDefault lib.kernel.unset;
+      };
+in
+
+buildLinux {
+  version = version;
+  modDirVersion = version;
+  src = kernelSrc;
+
+  structuredExtraConfig = {
+    LOCALVERSION = lib.kernel.freeform "-${ogc-revision}";
+  }
+  // kernelConfig;
+}


### PR DESCRIPTION
This change adds packaging of the OGC kernel for NixOS. Users can install the kernel by directly referencing the `OpenGamingCollective/kernel-packages` repo in their config.

To do:
- [x] Setup cachix cache for kernel artifacts (https://app.cachix.org/cache/opengamingcollective)
- [ ] Setup CI/CD to build and push artifacts upon a new tagged release