### PR TITLE
fix(arch): use different command for su

### DIFF
--- a/.github/workflows/arch.yaml
+++ b/.github/workflows/arch.yaml
@@ -230,7 +230,8 @@ jobs:
                   # Copy patched config
                   cp linux-${TAR_KVER}/.config /home/build/linux/arch/config
                   chown -R build /home/build/linux
-                  su build /usr/bin/bash -c "cd /home/build/linux/arch && MAKEFLAGS=-j$(nproc) makepkg --skippgpcheck --skipchecksums --skipinteg"
+                  cd /home/build/linux/arch 
+                  su build -c "MAKEFLAGS=-j$(nproc) makepkg --skippgpcheck --skipchecksums --skipinteg"
                   . /home/build/linux/arch/PKGBUILD
                   full_version=${pkgver}-${pkgrel}
                   echo "full_version=$full_version" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
The workflow for kernel builds on Arch Linux are currently broken. This PR should fix it.