### PR TITLE
feat(arch): use vendored 'linux-ogc' name

### DIFF
--- a/arch/PKGBUILD
+++ b/arch/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Jan Alexander Steffens (heftig) <heftig@archlinux.org>
 
-pkgbase=linux
+pkgbase=linux-ogc
 pkgver=@@OGC_VERSION@@
 pkgrel=@@BUILDNUM@@
 pkgdesc='Linux'


### PR DESCRIPTION
to avoid conflicts with the official 'linux' core packages.