### PR TITLE
fix(fedora): drop manual sign-file.c compilation

### DIFF
--- a/fedora/kernel.spec
+++ b/fedora/kernel.spec
@@ -351,11 +351,6 @@ cat .config > config-linux-ogc
 
 %build
 make %{?_smp_mflags} %{?llvm_build_env_vars} EXTRAVERSION=-%{krelstr}
-%if %{llvm_kbuild}
-clang -Iinclude -Iusr/include ./scripts/sign-file.c -o ./scripts/sign-file -lssl -lcrypto
-%else
-gcc -Iinclude -Iusr/include ./scripts/sign-file.c -o ./scripts/sign-file -lssl -lcrypto
-%endif
 
 # non-kernel userspace packages -- disable LTO
 %if "%{?_lto_cflags}" != ""


### PR DESCRIPTION
This binary should be compiled by the kernel make script.

Manual compilation within the spec is redundant and adds complications.