### PR TITLE
fix(fedora): add missing file to spec

### DIFF
--- a/fedora/kernel.spec
+++ b/fedora/kernel.spec
@@ -966,6 +966,7 @@ fi
 %{_mandir}/man1/rv-mon-wwnr.1.gz
 %{_mandir}/man1/rv-mon.1.gz
 %{_mandir}/man1/rv-mon-sched.1.gz
+%{_mandir}/man1/rv-mon-stall.1.gz
 %{_mandir}/man1/rv.1.gz
 
 %files


### PR DESCRIPTION
Fixes issue where man page was installed but not properly accounted.